### PR TITLE
Fix option hash key accepts both symbol and string

### DIFF
--- a/app/models/email_fetches.rb
+++ b/app/models/email_fetches.rb
@@ -20,11 +20,11 @@ module EmailFetches
 
     # Execute Redmine functions and return
     if configuration_type == 'imap'
-      Redmine::IMAP.check(email_options, MailHandler.extract_options_from_env(redmine_options))
+      Redmine::IMAP.check(email_options, MailHandler.extract_options_from_env(redmine_options.with_indifferent_access))
       self.update_attributes!(last_fetch_at: Time.now)
       return true
     elsif configuration_type == 'pop3'
-      Redmine::POP3.check(email_options, MailHandler.extract_options_from_env(redmine_options))
+      Redmine::POP3.check(email_options, MailHandler.extract_options_from_env(redmine_options.with_indifferent_access))
       self.update_attributes!(last_fetch_at: Time.now)
       return true
     else


### PR DESCRIPTION
In Redmine core, options are expected string hash key.

```ruby
  # Extracts MailHandler options from environment variables
  # Use when receiving emails with rake tasks
  def self.extract_options_from_env(env)
    options = {:issue => {}}
    %w(project status tracker category priority).each do |option|
      options[:issue][option.to_sym] = env[option] if env[option]
    end
    %w(allow_override unknown_user no_permission_check no_account_notice default_group).each do |option|
      options[option.to_sym] = env[option] if env[option]
    end
    options
  end
```

In this plugin, the options passed to extract_options_from_env(env) are symbol hash key.

```ruby
  def build_redmine_options
    ...
    redmine_options = { project: project.identifier,
                        status: default_status_name,
                        tracker: tracker.name,
                        ...
```

So, the ticket creation is failed.